### PR TITLE
[FIX] rma: fix split action read error.

### DIFF
--- a/rma/models/rma.py
+++ b/rma/models/rma.py
@@ -628,9 +628,10 @@ class Rma(models.Model):
         """Invoked when 'Split' button in rma form view is clicked."""
         self.ensure_one()
         self._ensure_can_be_split()
-        action = self.env.ref("rma.rma_split_wizard_action").read()[0]
+        action = self.env.ref("rma.rma_split_wizard_action").with_context(
+            active_id=self.id, active_ids=self.ids).read()[0]
         action['context'] = dict(self.env.context)
-        action['context'].update(active_ids=self.ids)
+        action['context'].update(active_id=self.id, active_ids=self.ids)
         return action
 
     def action_cancel(self):

--- a/rma/views/rma_portal_templates.xml
+++ b/rma/views/rma_portal_templates.xml
@@ -50,7 +50,8 @@
                             </a>
                         </td>
                         <td class="d-none d-md-table-cell"><span t-field="rma.date"/></td>
-                        <td><span t-field="rma.product_id.name"/></td>
+                        <!-- Portal users don't have access to unpublished products -->
+                        <td><span t-field="rma.sudo().product_id.name"/></td>
                         <td class='text-right'><span t-field="rma.product_uom_qty"/></td>
                         <td class="d-none d-md-table-cell tx_status">
                             <span class="badge badge-pill badge-secondary"><span t-field="rma.state"/></span>
@@ -132,12 +133,20 @@
                                         <span t-field="rma.picking_id"/>
                                     </div>
                                 </div>
-                                <div t-if="rma.product_id" class="row mb-2 mb-sm-1">
+                                <!-- We need to prevent access errors if the product is
+                                     unpublished. If not, we'll sudo to get the name-->
+                                <div t-if="rma.sudo().product_id" class="row mb-2 mb-sm-1">
                                     <div class="col-12 col-sm-4">
                                         <strong>Product</strong>
                                     </div>
                                     <div class="col-12 col-sm-8">
-                                        <span t-field="rma.product_id"/>
+                                        <!-- Don't depend on website -->
+                                        <t t-if="'website_published' in rma.sudo().product_id._fields and rma.sudo().product_id.website_published">
+                                            <span t-field="rma.product_id"/>
+                                        </t>
+                                        <t t-else="">
+                                            <span t-esc="rma.sudo().product_id.name"/>
+                                        </t>
                                     </div>
                                 </div>
                                 <div t-if="rma.product_uom_qty" class="row mb-2 mb-sm-1">
@@ -262,6 +271,9 @@
                 <h2>Communication</h2>
                 <t t-call="portal.message_thread">
                     <t t-set="object" t-value="rma"/>
+                    <t t-set="token" t-value="rma.access_token"/>
+                    <t t-set="pid" t-value="pid"/>
+                    <t t-set="hash" t-value="hash"/>
                 </t>
             </div>
         </t>

--- a/rma/wizard/rma_split_views.xml
+++ b/rma/wizard/rma_split_views.xml
@@ -29,6 +29,5 @@
         <field name="view_type">form</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
-        <field name="domain">[]</field>
     </record>
 </odoo>

--- a/rma/wizard/rma_split_views.xml
+++ b/rma/wizard/rma_split_views.xml
@@ -29,5 +29,6 @@
         <field name="view_type">form</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
+        <field name="domain">[]</field>
     </record>
 </odoo>


### PR DESCRIPTION
@chienandalu , https://github.com/OCA/rma/pull/160/files#diff-9d0ebf28f17fe12f2501dd239c3f038cR32 doesn't seem to fix the error when splitting. When you access a Picking form to the linked RMA and then try to split, the error is thrown.
Apparently when the read method is called here https://github.com/OCA/rma/blob/12.0/rma/models/rma.py#L631, the value of the active_id key is not updated in context to put the ID of the rma, so I think we can force that value on it, what do you think?